### PR TITLE
Add tests for PR#310

### DIFF
--- a/modules/libcom/src/misc/epicsString.c
+++ b/modules/libcom/src/misc/epicsString.c
@@ -231,6 +231,12 @@ int epicsStrPrintEscaped(FILE *fp, const char *s, size_t len)
 {
    int nout = 0;
 
+   if (fp == NULL)
+       return -1;
+
+   if (s == NULL || strlen(s) == 0 || len == 0)
+       return 0; // No work to do
+
    while (len--) {
        char c = *s++;
        int rc = 0;

--- a/modules/libcom/test/epicsStringTest.c
+++ b/modules/libcom/test/epicsStringTest.c
@@ -195,6 +195,32 @@ void testStrTok(void)
     testTok(NULL, " \t", "bbb ", "bbb", "");
 }
 
+static
+void testEpicsStrPrintEscaped(void)
+{   
+    const char *filename = "testEpicsStrPrintEscaped";
+    // Create a file then re-open it read only
+    FILE *readOnly = fopen(filename, "a");
+    fclose(readOnly);
+    readOnly = fopen(filename, "r");
+
+    testDiag("testEpicsStrPrintEscaped()");
+
+    // Passing cases
+    testOk1(epicsStrPrintEscaped(stdout, "1234", 4) == 4);
+    testOk1(epicsStrPrintEscaped(stdout, "\a\b\f\n\r\t\v\\\'\"", 10) == 20);
+
+    //Failing cases
+    testOk1(epicsStrPrintEscaped(readOnly, "1234", 4) == -1);
+    testOk1(epicsStrPrintEscaped(NULL, "1234", 4) == -1);
+    testOk1(epicsStrPrintEscaped(stdout, NULL, 4) == 0);
+    testOk1(epicsStrPrintEscaped(stdout, "", 4) == 0);
+    testOk1(epicsStrPrintEscaped(stdout, "1234", 0) == 0);
+
+    fclose(readOnly);
+    remove(filename);
+}
+
 MAIN(epicsStringTest)
 {
     const char * const empty = "";
@@ -209,7 +235,7 @@ MAIN(epicsStringTest)
     char *s;
     int status;
 
-    testPlan(439);
+    testPlan(446);
 
     testChars();
 
@@ -407,6 +433,7 @@ MAIN(epicsStringTest)
 
     testDistance();
     testStrTok();
+    testEpicsStrPrintEscaped();
 
     return testDone();
 }


### PR DESCRIPTION
The only way I could easily make `fprintf` fail was to try to write to a read-only file handle. Other ideas about closed file handles are all UB. Other error cases may come from running out of disk space or a file being deleted while the handle is still open, but these are hard to simulate (and will also just return a negative number). 

Please let me know if there are more ways to make this call fail.

